### PR TITLE
Fixed compatibility issue with SublimeLinter package.

### DIFF
--- a/Oasis.tmTheme
+++ b/Oasis.tmTheme
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "something@somewhere.ops">
+<!DOCTYPE plist PUBLIC "//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>name</key>


### PR DESCRIPTION
This is fix for this issue https://github.com/kodLite/Oasis-Theme/issues/1
I pasted original text provided by Apple, since Apple originally introduced property list format and as far as I can judge it is a common practice to keep it that way.
